### PR TITLE
F2019 - Threads error for ruby >= 2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 rottenpotatoes/.bundle/
 rottenpotatoes/.rspec
+rottenpotatoes/.ruby-version
 rottenpotatoes/coverage/
 rottenpotatoes/db/*.sqlite3
 rottenpotatoes/db/schema.rb

--- a/rottenpotatoes/Gemfile
+++ b/rottenpotatoes/Gemfile
@@ -1,9 +1,7 @@
 source 'https://rubygems.org'
 
-ruby '2.4.0'
+ruby '>= 2.4.0'
 gem 'rails', '4.2.10'
-# Bundle edge Rails instead:
-# gem 'rails',     :git => 'git://github.com/rails/rails.git'
 
 # for Heroku deployment - as described in Ap. A of ELLS book
 group :development, :test do
@@ -13,7 +11,7 @@ group :development, :test do
   gem 'capybara', '2.4.4'
   gem 'launchy'
   gem 'rspec-rails', '3.7.2'
-  gem 'ZenTest', '4.11.0'
+  gem 'ZenTest', '4.11.2'
 end
 
 group :test do
@@ -21,22 +19,14 @@ group :test do
   gem 'cucumber-rails-training-wheels'
 end
 group :production do
-  gem 'pg'
+  #gem 'pg'
 end
 
 # Gems used only for assets and not required
 # in production environments by default.
 
-  #gem 'therubyracer', '~> 0.12.0'
 gem 'sass-rails', '~> 5.0.3'
 gem 'coffee-rails', '~> 4.1.0'
 gem 'uglifier', '>= 2.7.1'
-
 gem 'jquery-rails'
 gem 'haml'
-
-# Use unicorn as the web server
-# gem 'unicorn'
-
-# Deploy with Capistrano
-# gem 'capistrano'

--- a/rottenpotatoes/Gemfile
+++ b/rottenpotatoes/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '>= 2.4.0'
+ruby '>= 2.4.0', '< 2.6'
 gem 'rails', '4.2.10'
 
 # for Heroku deployment - as described in Ap. A of ELLS book

--- a/rottenpotatoes/Gemfile.lock
+++ b/rottenpotatoes/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ZenTest (4.11.0)
+    ZenTest (4.11.2)
     actionmailer (4.2.10)
       actionpack (= 4.2.10)
       actionview (= 4.2.10)
@@ -106,7 +106,6 @@ GEM
     multi_test (0.1.2)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
-    pg (0.18.4)
     rack (1.6.10)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -181,7 +180,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  ZenTest (= 4.11.0)
+  ZenTest (= 4.11.2)
   byebug
   capybara (= 2.4.4)
   coffee-rails (~> 4.1.0)
@@ -191,7 +190,6 @@ DEPENDENCIES
   haml
   jquery-rails
   launchy
-  pg
   rails (= 4.2.10)
   rspec-rails (= 3.7.2)
   sass-rails (~> 5.0.3)
@@ -202,4 +200,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.16.1
+   1.17.3


### PR DESCRIPTION
ruby over/equal to 2.6 gives a thread error:

```
     Failure/Error: get :same_director
     
     ThreadError:
       already initialized
     # /var/lib/gems/2.6.0/gems/actionpack-4.2.10/lib/action_dispatch/http/response.rb:119:in `initialize'
     # /var/lib/gems/2.6.0/gems/actionpack-4.2.10/lib/action_controller/test_case.rb:277:in `recycle!'
     # /var/lib/gems/2.6.0/gems/actionpack-4.2.10/lib/action_controller/test_case.rb:617:in `process'
     # /var/lib/gems/2.6.0/gems/actionpack-4.2.10/lib/action_controller/test_case.rb:67:in `process'
     # /var/lib/gems/2.6.0/gems/actionpack-4.2.10/lib/action_controller/test_case.rb:514:in `get'
     # ./spec/controllers/movies_controller_spec.rb:8:in `block (3 levels) in <top (required)>'
``` 